### PR TITLE
More detailed charge status

### DIFF
--- a/JumpSelector/Plugin/JumpSelectorGui.cs
+++ b/JumpSelector/Plugin/JumpSelectorGui.cs
@@ -295,7 +295,15 @@ namespace JumpSelector.Plugin
             }
             if (!jd.Enabled)
             {
-                text = "[Off] ";
+                if (jd.StoredPowerRatio < 1f)
+                {
+                    float num = jd.StoredPowerRatio * 100f;
+                    text = $"[Off {num:N1}%] ";
+                }
+                else
+                {
+                    text = "[Off] ";
+                }
                 item = Color.Red;
             }
             if (jd.SlimBlock.IsDestroyed)

--- a/JumpSelector/Plugin/JumpSelectorGui.cs
+++ b/JumpSelector/Plugin/JumpSelectorGui.cs
@@ -6,6 +6,7 @@ using Sandbox.Game.Entities;
 using Sandbox.Game.GameSystems;
 using Sandbox.Game.World;
 using Sandbox.Graphics.GUI;
+using Sandbox.ModAPI;
 using SpaceEngineers.Game.ModAPI;
 using VRage;
 using VRage.Audio;
@@ -290,8 +291,16 @@ namespace JumpSelector.Plugin
             if (jd.StoredPowerRatio < 1.0)
             {
                 float num = jd.StoredPowerRatio * 100f;
-                text = string.Format("[Charging {0:N1}%] ", num);
-                item = Color.Yellow;
+                if (!((IMyJumpDrive)jd).Recharge)
+                {
+                    text = string.Format("[Not Charging {0:N1}%] ", num);
+                    item = Color.Orange;
+                }
+                else
+                {
+                    text = string.Format("[Charging {0:N1}%] ", num);
+                    item = Color.Yellow;
+                }
             }
             if (!jd.Enabled)
             {


### PR DESCRIPTION
- Show charge status in the tooltip if drive is off and has <1f charge
- Change tooltip to "Not Charging" and use orange border instead of yellow if recharge is off